### PR TITLE
Fix WX14 bugs

### DIFF
--- a/CardInfo.js
+++ b/CardInfo.js
@@ -90658,6 +90658,7 @@ var CardInfo = {
 					triggerCondition: function (event) {
 						if (!inArr(this,this.player.signis)) return false;
 						if (!this.game.getEffectSource()) return false;
+						if (!event.card.hasClass('アーム')) return false;
 						return true;
 					},
 					actionAsyn: function () {

--- a/CardInfo.js
+++ b/CardInfo.js
@@ -87852,6 +87852,9 @@ var CardInfo = {
 				var effect = this.game.newEffect({
 					source: this,
 					description: '1437-const-0',
+					triggerCondition: function () {
+						return !this.player.addCardTohandBanned
+					},
 					actionAsyn: function () {
 						this.player.draw(1);
 					}

--- a/CardInfo.js
+++ b/CardInfo.js
@@ -87853,9 +87853,6 @@ var CardInfo = {
 				var effect = this.game.newEffect({
 					source: this,
 					description: '1437-const-0',
-					triggerCondition: function () {
-						return !this.player.addCardTohandBanned
-					},
 					actionAsyn: function () {
 						this.player.draw(1);
 					}

--- a/CardInfo.js
+++ b/CardInfo.js
@@ -86292,6 +86292,7 @@ var CardInfo = {
 		"imgUrl": "http://www.takaratomy.co.jp/products/wixoss/wxwp/images/card/WX11/WX11-013.jpg",
 		"illust": "bomi",
 		"classes": [
+			"精羅",
 			"宇宙"
 		],
 		"costWhite": 0,

--- a/Player.js
+++ b/Player.js
@@ -261,6 +261,7 @@ Player.prototype.up = function () {
 // 返回:
 //   cards: Array,抽到的卡,长度可能少于n(卡组没有足够的卡可以抽),也可能为空数组.
 Player.prototype.draw = function (n) {
+	if (this.addCardToHandBanned) return [];
 	var cards = this.mainDeck.getTopCards(n);
 	if (!cards.length) return [];
 	if (this.game.phase.isAttackPhase()) {


### PR DESCRIPTION
#23 修复部分 Bugs:
1. 无法阻止 **抽牌效果** 发动 `大白鲨 x 爱心代号cmr`

- [x] 已修改
- [x] 已测试

2. 修复 `白罗星 阋神星` 的类型为 `精罗：宇宙`
- [x] 已修改

3. `蝙蝠车` 添加 `武装` 判断 
- [x] 已修改
- [x] 已测试

4. `水天一碧` 将 `胡桃夹子` 从能量区移动到手牌，发动后者的效果
- [x] 已测试 无问题