### PR TITLE
Fixup wixoss images download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
   ```
   cd webxoss-client
-  curl http://webxoss.com/images.tar | tar xv
+  curl https://webxoss.com/images.tar | tar xv
   cd -
   ```
 


### PR DESCRIPTION
use https instead of http

close #68 